### PR TITLE
Chore/types unify pr

### DIFF
--- a/project-pr-nextjs/src/app/components/PullRequestCard.tsx
+++ b/project-pr-nextjs/src/app/components/PullRequestCard.tsx
@@ -1,64 +1,29 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import type { OpenPullRequest } from "@/types/pr";
 
-interface Reviewer {
-  name: string;
-  role: string;
-}
-
-export interface PullRequest {
-  id: number;
-  title: string;
-  author: string;
-  createdAt: string;
-  updatedAt: string;
-  closedOn: string;
-  age: string;
-  status: "Unapproved" | "Pending approvals" | "Requested changes" | "Approved" | "Closed" | "Merged";
-  url: string;
-  lastAction: string;
-  lastActionAt: string;
-  reviewersGrouped: {
-    approved: string[];
-    changesRequested: string[];
-    commented: string[];
-    pending: string[];
-  };
-}
-
-export default function PullRequestCard({ pr }: { pr: PullRequest }) {
+export default function PullRequestCard({ pr }: { pr: OpenPullRequest }) {
   return (
-    <a
-      href={pr.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="block"
-    >
+    <a href={pr.url} target="_blank" rel="noopener noreferrer" className="block">
       <div
-        className={`bg-[#161b22] mx-auto sm:mx-16 border border-[#30363D] rounded-lg p-4 hover:bg-[#30363D]/80 transition w-[500px] h-[180px] sm:w-auto sm:h-auto
-        ${cn(
+        className={cn(
+          "bg-[#161b22] mx-auto sm:mx-16 border border-[#30363D] rounded-lg p-4 hover:bg-[#30363D]/80 transition w-[500px] h-[180px] sm:w-auto sm:h-auto",
           pr.status === "Unapproved" && "border-l-2 border-l-amber-600",
           pr.status === "Pending approvals" && "border-l-2 border-l-yellow-600",
           pr.status === "Requested changes" && "border-l-2 border-l-red-600",
-          pr.status === "Approved" && "border-l-2 border-l-green-600",
-          pr.status === "Closed" && "border-l-2 border-l-red-600",
-          pr.status === "Merged" && "border-l-2 border-l-purple-600"
-        )}`}
+          pr.status === "Approved" && "border-l-2 border-l-green-600"
+        )}
       >
         <div className="flex justify-between items-center mb-2">
-          <h2 className="font-semibold text-lg">
-            #{pr.id} {pr.title}
-          </h2>
+          <h2 className="font-semibold text-lg">#{pr.id} {pr.title}</h2>
           <span
             className={cn(
               "px-3 py-2 text-xs rounded-md font-bold h-auto w-auto",
               pr.status === "Unapproved" && "bg-amber-600 text-white",
               pr.status === "Pending approvals" && "bg-yellow-600 text-white",
               pr.status === "Requested changes" && "bg-red-700 text-white",
-              pr.status === "Approved" && "bg-green-600 text-white",
-              pr.status === "Closed" && "bg-red-600 text-white",
-              pr.status === "Merged" && "bg-purple-600 text-white"
+              pr.status === "Approved" && "bg-green-600 text-white"
             )}
           >
             {pr.status}
@@ -79,77 +44,51 @@ export default function PullRequestCard({ pr }: { pr: PullRequest }) {
           >
             {pr.lastAction}
           </span>{" "}
-          •{" "}
-          <span
-            className={cn(
-              pr.lastAction === "Approved" && "text-green-600",
-              pr.lastAction === "Requested changes" && "text-red-600",
-              pr.lastAction === "Commented" && "text-yellow-600",
-              pr.lastAction === "Unapproved" && "text-amber-600",
-              !pr.lastAction && "text-gray-400"
-            )}
-          >
-            {pr.lastActionAt}h ago
-          </span>
+          • <span className="text-gray-400">{pr.lastActionAt}h ago</span>
         </p>
 
         <div className="mt-3 space-y-1 text-gray-400 text-sm">
           {pr.reviewersGrouped.pending.length > 0 && (
             <div>
               <span className="font-bold mr-2 text-gray-400">Pending:</span>
-              <span>
-                {pr.reviewersGrouped.pending.map((name, i) => (
-                  <span key={name} className="text-gray-400 italic">
-                    {name}
-                    {i < pr.reviewersGrouped.pending.length - 1 && " | "}
-                  </span>
-                ))}
-              </span>
+              {pr.reviewersGrouped.pending.map((name, i) => (
+                <span key={name} className="text-gray-400 italic">
+                  {name}{i < pr.reviewersGrouped.pending.length - 1 && " | "}
+                </span>
+              ))}
             </div>
           )}
 
           {pr.reviewersGrouped.approved.length > 0 && (
             <div>
               <span className="font-bold mr-2 text-gray-400">Approved:</span>
-              <span>
-                {pr.reviewersGrouped.approved.map((name, i) => (
-                  <span key={name} className="text-gray-400 italic">
-                    {name}
-                    {i < pr.reviewersGrouped.approved.length - 1 && " | "}
-                  </span>
-                ))}
-              </span>
+              {pr.reviewersGrouped.approved.map((name, i) => (
+                <span key={name} className="text-gray-400 italic">
+                  {name}{i < pr.reviewersGrouped.approved.length - 1 && " | "}
+                </span>
+              ))}
             </div>
           )}
 
           {pr.reviewersGrouped.changesRequested.length > 0 && (
             <div>
-              <span className="font-bold mr-2 text-gray-400">
-                Requested changes:
-              </span>
-              <span>
-                {pr.reviewersGrouped.changesRequested.map((name, i) => (
-                  <span key={name} className="text-gray-400 italic">
-                    {name}
-                    {i < pr.reviewersGrouped.changesRequested.length - 1 &&
-                      "  |  "}
-                  </span>
-                ))}
-              </span>
+              <span className="font-bold mr-2 text-gray-400">Requested changes:</span>
+              {pr.reviewersGrouped.changesRequested.map((name, i) => (
+                <span key={name} className="text-gray-400 italic">
+                  {name}{i < pr.reviewersGrouped.changesRequested.length - 1 && " | "}
+                </span>
+              ))}
             </div>
           )}
 
           {pr.reviewersGrouped.commented.length > 0 && (
             <div>
               <span className="font-bold mr-2 text-gray-400">Commented:</span>
-              <span>
-                {pr.reviewersGrouped.commented.map((name, i) => (
-                  <span key={name} className="text-gray-400 italic">
-                    {name}
-                    {i < pr.reviewersGrouped.commented.length - 1 && " | "}
-                  </span>
-                ))}
-              </span>
+              {pr.reviewersGrouped.commented.map((name, i) => (
+                <span key={name} className="text-gray-400 italic">
+                  {name}{i < pr.reviewersGrouped.commented.length - 1 && " | "}
+                </span>
+              ))}
             </div>
           )}
         </div>

--- a/project-pr-nextjs/src/app/components/PullRequestCardClosedPageTemp.tsx
+++ b/project-pr-nextjs/src/app/components/PullRequestCardClosedPageTemp.tsx
@@ -1,46 +1,28 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import type { ClosedPullRequest } from "@/types/pr";
 
-interface Reviewer {
-  name: string;
-  role: string;
-}
+type Props = { pr: ClosedPullRequest };
 
-export interface PullRequest {
-  id: number;
-  title: string;
-  author: string;
-  createdAt: string;
-  updatedAt: string;
-  closedOn: string;
-  age: string;
-  reviewers: Reviewer[];
-  status: "Need Review" | "In Review" | "Draft" | "Closed" | "Merged";
-}
-
-export default function PullRequestCard({ pr }: { pr: PullRequest }) {
+export default function PullRequestCardClosed({ pr }: Props) {
   return (
-   
-    <div className={`bg-[#161b22] mx-auto sm:mx-16 border border-[#30363D] rounded-lg p-4 hover:bg-[#30363D]/80 transition w-[500px] h-[180px] sm:w-auto sm:h-auto
-    ${cn(
-      parseInt(pr.age) > 48
-      ? " border border-l-red-400"
-      :parseInt(pr.age) >= 24
-      ? "border border-l-yellow-400"
-      : "border border-l-green-400"
-    )}`}
+    <div
+      className={cn(
+        "bg-[#161b22] mx-auto sm:mx-16 border border-[#30363D] rounded-lg p-4 hover:bg-[#30363D]/80 transition w-[500px] h-[180px] sm:w-auto sm:h-auto",
+        parseInt(pr.age) > 48
+          ? "border-l-2 border-l-red-400"
+          : parseInt(pr.age) >= 24
+          ? "border-l-2 border-l-yellow-400"
+          : "border-l-2 border-l-green-400"
+      )}
     >
       <div className="flex justify-between items-center mb-2">
-        <h2 className="font-semibold text-lg">
-          #{pr.id} {pr.title}
-        </h2>
+        <h2 className="font-semibold text-lg">#{pr.id} {pr.title}</h2>
         <span
           className={cn(
             "px-2 py-1 text-xs rounded-md font-bold h-auto w-auto",
-            pr.status === "Need Review" && "bg-yellow-600 text-white",
-            pr.status === "In Review" && "bg-blue-600 text-white",
-            pr.status === "Draft" && "bg-gray-600 text-white",
+            pr.status === "Draft"  && "bg-gray-600 text-white",
             pr.status === "Closed" && "bg-red-600 text-white",
             pr.status === "Merged" && "bg-purple-600 text-white"
           )}
@@ -50,32 +32,21 @@ export default function PullRequestCard({ pr }: { pr: PullRequest }) {
       </div>
 
       <p className="text-sm text-gray-400">
-        by <span className="font-medium text-white">{pr.author}</span> • created{" "}
-        {pr.createdAt} • updated {pr.updatedAt} •{" "}
+        by <span className="font-medium text-white">{pr.author}</span> •
+        {" "}created {pr.createdAt} • updated {pr.updatedAt} •{" "}
         <span
           className={cn(
             parseInt(pr.age) > 48
               ? "text-red-400"
               : parseInt(pr.age) >= 24
               ? "text-yellow-400"
-              : "text-green-400 "
+              : "text-green-400"
           )}
         >
           {pr.age}
-        </span>
+        </span>{" "}
+        • closed on {pr.closedOn}
       </p>
-
-      <div className="flex gap-2 mt-3">
-        {pr.reviewers.map((rev) => (
-          <span
-            key={rev.name}
-            className="inline-flex items-center px-2.5 py-1 rounded-full text-xs 
-            font-medium max-w-full border border-blue-700 text-blue-200 bg-blue-900"
-          >
-            {rev.name}
-          </span>
-        ))}
-      </div>
     </div>
   );
 }

--- a/project-pr-nextjs/src/app/components/filter.tsx
+++ b/project-pr-nextjs/src/app/components/filter.tsx
@@ -3,9 +3,15 @@
 import React, { useState, useRef } from 'react'
 import { PullRequest } from './PullRequestCard';
 
-export default function Filter() {
+interface FilterProps {
+  onSearchChange?: (term: string) => void;
+  currentState?: "open" | "closed"; // optional: filter mode
+}
+
+export default function Filter({ onSearchChange }: FilterProps) {
   const [isRepoDropdownOpen, setIsRepoDropdownOpen] = useState(false);
   const [isCachingDropdownOpen, setIsCachingDropdownOpen] = useState(false);
+  const [query, setQuery] = useState("");   
   //const divRef = useRef<HTMLDivElement | null>(null); 
 
   const toggleRepoDropdown = () => {
@@ -65,7 +71,17 @@ export default function Filter() {
 
  <div className="flex-1 lg:max-w-md px-4 lg:px-0 w-full">
       <div className="relative">
-        <input type="text" id="globalSearch" placeholder="Search PRs..." className="w-full h-auto lg:h-[34px] bg-slate-950 border border-[#30363D] rounded-lg pl-9 pr-4 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"/>
+        <input type="text" 
+          id="globalSearch" 
+          placeholder="Search PRs..." 
+          className="w-full h-auto lg:h-[34px] bg-slate-950 border border-[#30363D] rounded-lg pl-9 pr-4 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          value={query}
+          onChange={(e) => {
+            const val = e.target.value;
+            setQuery(val);
+            onSearchChange?.(val);
+          }}
+          />
         <svg className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
           <path d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"></path>
         </svg>

--- a/project-pr-nextjs/src/app/openRequests/page.tsx
+++ b/project-pr-nextjs/src/app/openRequests/page.tsx
@@ -25,8 +25,8 @@ export default function OpenPRsPage() {
         const { data } = await octokit.request(
           "GET /repos/{owner}/{repo}/pulls",
           {
-            owner: process.env.NEXT_PUBLIC_GITHUB_ORG,
-            repo: process.env.NEXT_PUBLIC_GITHUB_REPO_NAME,
+            owner: process.env.NEXT_PUBLIC_GITHUB_ORG as string,
+            repo: process.env.NEXT_PUBLIC_GITHUB_REPO_NAME as string,
             state: "open",
             headers: { "X-GitHub-Api-Version": "2022-11-28" },
           }
@@ -34,6 +34,9 @@ export default function OpenPRsPage() {
 
         const formatted: PullRequest[] = await Promise.all(
           data.map(async (pr: any) => {
+            type PRStatus = PullRequest["status"]; 
+            let status: PRStatus = "Unapproved";
+            
             const { data: reviews } = await octokit.request(
               "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
               {

--- a/project-pr-nextjs/src/app/search/page.tsx
+++ b/project-pr-nextjs/src/app/search/page.tsx
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { Octokit } from "octokit";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get("q") || "";
+  const githubOrg = process.env.NEXT_PUBLIC_GITHUB_ORG;
+  const githubRepoName = process.env.NEXT_PUBLIC_GITHUB_REPO_NAME;
+  const githubToken = process.env.GITHUB_TOKEN; // safer than NEXT_PUBLIC
+
+  if (!githubOrg || !githubRepoName) {
+    return NextResponse.json(
+      { error: "Missing GitHub org or repo name" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const octokit = new Octokit(
+      githubToken ? { auth: githubToken } : undefined
+    );
+
+    const response = await octokit.request("GET /search/issues", {
+      q: `${query} repo:${githubOrg}/${githubRepoName} type:pr in:title,body`,
+    });
+
+    const results = response.data.items.map((item: any) => ({
+      id: item.number,
+      title: item.title,
+      author: item.user?.login,
+      state: item.state,
+      html_url: item.html_url,
+      updated_at: item.updated_at,
+      created_at: item.created_at,
+    }));
+
+    return NextResponse.json(results);
+  } catch (error) {
+    console.error("Error fetching issues:", error);
+    return NextResponse.json(
+      { error: "Error fetching GitHub search results" },
+      { status: 500 }
+    );
+  }
+}

--- a/project-pr-nextjs/src/types/pr.ts
+++ b/project-pr-nextjs/src/types/pr.ts
@@ -1,0 +1,63 @@
+// src/types/pr.ts
+
+// Shared bits
+export interface Reviewer {
+  name: string;
+  role?: string;
+}
+
+interface BasePR {
+  id: number;
+  title: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+  age: string;          // hours since last action (string in your UIs)
+}
+
+// === Open PRs ===============================================================
+export type OpenPRStatus =
+  | "Unapproved"
+  | "Pending approvals"
+  | "Requested changes"
+  | "Approved"
+  | "Draft"; // allow Draft here to avoid unions bleeding in from the closed card
+
+export interface OpenPullRequest extends BasePR {
+  url: string;
+  lastAction: string;
+  lastActionAt: string;
+  status: OpenPRStatus;
+  reviewersGrouped: {
+    approved: string[];
+    changesRequested: string[];
+    commented: string[];
+    pending: string[];
+  };
+  closedOn?: string; // not used on the open card, but harmless if present
+}
+
+// === Closed PRs =============================================================
+export type ClosedPRStatus =
+  | "Need Review"
+  | "In Review"
+  | "Draft"
+  | "Closed"
+  | "Merged";
+
+export interface ClosedPullRequest extends BasePR {
+  closedOn: string;
+  status: ClosedPRStatus;
+  reviewers: Reviewer[];
+}
+
+// Optional helpers
+export type AnyPullRequest = OpenPullRequest | ClosedPullRequest;
+
+export function isOpenPR(pr: AnyPullRequest): pr is OpenPullRequest {
+  return "reviewersGrouped" in pr;
+}
+
+export function isClosedPR(pr: AnyPullRequest): pr is ClosedPullRequest {
+  return "reviewers" in pr;
+}

--- a/project-pr-nextjs/tsconfig.json
+++ b/project-pr-nextjs/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/types/*": ["./src/types/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
-// import { Pool } from "pg";
+import { Pool } from "pg";
 
 dotenv.config();
 


### PR DESCRIPTION
This PR centralizes our PR-related TypeScript types into a single source 
PR card components to use them
goal is to remove union/type conflicts between Open/Closed PR views and unblock the search work.
Make code readable and succent as we had problematic issues when calling on react hooks. 
What changed;
Added: src/types/pr.ts
Reviewer (shared)
OpenPRStatus = "Unapproved" | "Pending approvals" | "Requested changes" | "Approved"
ClosedPRStatus = "Closed" | "Merged" | "Draft" | "Need Review" | "In Review" (adjust if we only use a subset on the closed page)
ReviewerGroups for grouped review state
OpenPullRequest (includes url, lastAction, lastActionAt, reviewersGrouped)
ClosedPullRequest (includes reviewers, no grouped fields)
Refactor: src/app/components/PullRequestCard.tsx
Uses OpenPullRequest and OpenPRStatus (removes comparisons against Closed-only statuses).
Refactor: src/app/components/PullRequestCardClosedPageTemp.tsx
Uses ClosedPullRequest and ClosedPRStatus.
Housekeeping: Imports now come from @/types/pr.
Why
We had status unions defined inside components, and Open code path was comparing to Closed statuses (“Closed”, “Merged”), causing TypeScript errors and confusion.
Centralized types make it obvious which fields/statuses belong to which page and makes search/filter typing straightforward.
Notes / Scope
No API or UI behavior changes intended—this is typing + component-level cleanup only.
The Temp suffix on the closed card remains for now; happy to rename in a follow-up (ClosedPullRequestCard.tsx) if we want to finish that in this PR.
Search wiring will consume these shared types next (propagate onSearchChange from Filter to pages and filter against OpenPullRequest fields).
How to review
Focus files:
src/types/pr.ts
src/app/components/PullRequestCard.tsx
src/app/components/PullRequestCardClosedPageTemp.tsx (why is it called temp???)
Sanity check that:
Open card only uses OpenPRStatus.
Closed card only uses ClosedPRStatus.
Imports reference @/types/pr (no local interface duplication).
Optional follow-up: rename closed card file and update imports.